### PR TITLE
Update node-pre-gyp dependency to @mapbox/node-pre-gyp

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "test-ts-out": "node ./bin/protoc-gen-grpc-ts.js --ts_out=grpc_js:./examples/src/proto --proto_path ./examples/proto ./examples/proto/product.proto"
   },
   "bundledDependencies": [
-    "node-pre-gyp"
+    "@mapbox/node-pre-gyp"
   ],
   "binary": {
     "module_name": "grpc_tools",
@@ -49,6 +49,6 @@
     "@types/node": "^15.12.2",
     "coveralls": "^3.1.0",
     "jest": "^27.0.4",
-    "node-pre-gyp": "^0.17.0"
+    "@mapbox/node-pre-gyp": "^1.0.5"
   }
 }


### PR DESCRIPTION
node-pre-gyp is no longer maintained and has been deprecated in favor of `@mapbox/node-pre-gyp`

Also, there is currently a pending proposal to update `tar` version in `@mapbox/node-pre-gyp` to mitigate the following security vulnerabilities:
https://www.npmjs.com/advisories/1770
https://www.npmjs.com/advisories/1771

https://github.com/mapbox/node-pre-gyp/commit/54fc2048f0ec4ab7ff1d2b55a0d4c4492ed5df9c