### PR TITLE
Bump grpc-tools binary dependency to v1.11.3 which has pre-compiled M1 binaries

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "binary": {
     "module_name": "grpc_tools",
     "host": "https://node-precompiled-binaries.grpc.io/",
-    "remote_path": "grpc-tools/v1.11.1",
+    "remote_path": "grpc-tools/v1.11.3",
     "package_name": "{platform}-{arch}.tar.gz",
     "module_path": "bin"
   },


### PR DESCRIPTION
v1.11.3 is the first version of grpc-tools to ship with precompiled binaries for M1.

See https://github.com/grpc/grpc-node/issues/1405#issuecomment-1268791265.

This solves the following issue that can happen on M1:

```
node-pre-gyp info it worked if it ends with ok
node-pre-gyp info using node-pre-gyp@1.0.10
node-pre-gyp info using node@16.17.1 | darwin | arm64
node-pre-gyp info check checked for "/Users/gregmagolan/src/coda/node_modules/grpc-tools/bin/grpc_tools.node" (not found)
node-pre-gyp http GET https://node-precompiled-binaries.grpc.io/grpc-tools/v1.11.2/darwin-arm64.tar.gz
node-pre-gyp ERR! install response status 404 Not Found on https://node-precompiled-binaries.grpc.io/grpc-tools/v1.11.2/darwin-arm64.tar.gz 
node-pre-gyp ERR! install error 
node-pre-gyp ERR! stack Error: response status 404 Not Found on https://node-precompiled-binaries.grpc.io/grpc-tools/v1.11.2/darwin-arm64.tar.gz
node-pre-gyp ERR! stack     at /Users/gregmagolan/src/coda/node_modules/@mapbox/node-pre-gyp/lib/install.js:67:15
node-pre-gyp ERR! stack     at processTicksAndRejections (node:internal/process/task_queues:96:5)
node-pre-gyp ERR! System Darwin 21.6.0
node-pre-gyp ERR! command "/private/var/tmp/_bazel_gregmagolan/992bb88de044c9af314b149412f58114/external/nodejs_darwin_arm64/bin/nodejs/bin/node" "/Users/gregmagolan/src/coda/node_modules/grpc-tools/node_modules/.bin/node-pre-gyp" "install"
node-pre-gyp ERR! cwd /Users/gregmagolan/src/coda/node_modules/grpc-tools
node-pre-gyp ERR! node -v v16.17.1
node-pre-gyp ERR! node-pre-gyp -v v1.0.10
node-pre-gyp ERR! not ok 
response status 404 Not Found on https://node-precompiled-binaries.grpc.io/grpc-tools/v1.11.2/darwin-arm64.tar.gz
```